### PR TITLE
Implement Firefox support

### DIFF
--- a/background.js
+++ b/background.js
@@ -30,20 +30,23 @@ function sendMessage(type, data, tabId = null) {
 }
 
 chrome.runtime.onInstalled.addListener(function() {
-	chrome.declarativeContent.onPageChanged.removeRules(undefined, function() {
-		chrome.declarativeContent.onPageChanged.addRules([
-			{
-				conditions: [
-					new chrome.declarativeContent.PageStateMatcher({
-						pageUrl: {
-							hostContains: 'twitch'
-						}
-					})
-				],
-				actions: [new chrome.declarativeContent.ShowPageAction()]
-			}
-		]);
-	});
+  if (typeof chrome.declarativeContent !== "undefined") {
+    // Supports chrome.declarativeContent
+    chrome.declarativeContent.onPageChanged.removeRules(undefined, function () {
+      chrome.declarativeContent.onPageChanged.addRules([
+        {
+          conditions: [
+            new chrome.declarativeContent.PageStateMatcher({
+              pageUrl: {
+                hostContains: "twitch",
+              },
+            }),
+          ],
+          actions: [new chrome.declarativeContent.ShowPageAction()],
+        },
+      ]);
+    });
+  }
 });
 
 function saveSettings() {
@@ -81,7 +84,18 @@ chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
 	if (changeInfo.url) {
 		sendMessage('URL_CHANGE', changeInfo.url, tabId);
 		loadSettings();
-	}
+  }
+
+  if (typeof chrome.declarativeContent === 'undefined') {
+    // Doesn't support chrome.declarativeContent
+    if (changeInfo.status === "complete") {
+      if (/twitch/.test(tab.url)) {
+        chrome.pageAction.show(tabId);
+      } else {
+        chrome.pageAction.hide(tabId);
+      }
+    }
+  }
 });
 
 chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
@@ -95,13 +109,20 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 			saveSettings();
 			break;
 		case 'GET_FONTS':
-			chrome.fontSettings.getFontList(data => {
-				fonts = ['Default'];
-				for (let font of data) {
-					fonts.push(font.displayName);
-				}
-				sendMessage('GOT_FONTS', fonts);
-			});
+      if (typeof chrome.fontSettings !== "undefined") {
+        // Supports chrome.fontSettings
+        chrome.fontSettings.getFontList((data) => {
+          fonts = ["Default"];
+          for (let font of data) {
+            fonts.push(font.displayName);
+          }
+          sendMessage("GOT_FONTS", fonts);
+        });
+      } else {
+        Promise.resolve().then(() => {
+          sendMessage("GOT_FONTS", fonts);
+        });
+      }
 			break;
 	}
 });

--- a/background.js
+++ b/background.js
@@ -30,23 +30,23 @@ function sendMessage(type, data, tabId = null) {
 }
 
 chrome.runtime.onInstalled.addListener(function() {
-  if (typeof chrome.declarativeContent !== "undefined") {
-    // Supports chrome.declarativeContent
-    chrome.declarativeContent.onPageChanged.removeRules(undefined, function () {
-      chrome.declarativeContent.onPageChanged.addRules([
-        {
-          conditions: [
-            new chrome.declarativeContent.PageStateMatcher({
-              pageUrl: {
-                hostContains: "twitch",
-              },
-            }),
-          ],
-          actions: [new chrome.declarativeContent.ShowPageAction()],
-        },
-      ]);
-    });
-  }
+	if (typeof chrome.declarativeContent !== "undefined") {
+		// Supports chrome.declarativeContent
+		chrome.declarativeContent.onPageChanged.removeRules(undefined, function () {
+			chrome.declarativeContent.onPageChanged.addRules([
+				{
+					conditions: [
+						new chrome.declarativeContent.PageStateMatcher({
+							pageUrl: {
+								hostContains: "twitch",
+							},
+						}),
+					],
+					actions: [new chrome.declarativeContent.ShowPageAction()],
+				},
+			]);
+		});
+	}
 });
 
 function saveSettings() {
@@ -84,18 +84,18 @@ chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
 	if (changeInfo.url) {
 		sendMessage('URL_CHANGE', changeInfo.url, tabId);
 		loadSettings();
-  }
+	}
 
-  if (typeof chrome.declarativeContent === 'undefined') {
-    // Doesn't support chrome.declarativeContent
-    if (changeInfo.status === "complete") {
-      if (/twitch/.test(tab.url)) {
-        chrome.pageAction.show(tabId);
-      } else {
-        chrome.pageAction.hide(tabId);
-      }
-    }
-  }
+	if (typeof chrome.declarativeContent === 'undefined') {
+		// Doesn't support chrome.declarativeContent
+		if (changeInfo.status === "complete") {
+			if (/twitch/.test(tab.url)) {
+				chrome.pageAction.show(tabId);
+			} else {
+				chrome.pageAction.hide(tabId);
+			}
+		}
+	}
 });
 
 chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
@@ -109,20 +109,20 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 			saveSettings();
 			break;
 		case 'GET_FONTS':
-      if (typeof chrome.fontSettings !== "undefined") {
-        // Supports chrome.fontSettings
-        chrome.fontSettings.getFontList((data) => {
-          fonts = ["Default"];
-          for (let font of data) {
-            fonts.push(font.displayName);
-          }
-          sendMessage("GOT_FONTS", fonts);
-        });
-      } else {
-        Promise.resolve().then(() => {
-          sendMessage("GOT_FONTS", fonts);
-        });
-      }
+			if (typeof chrome.fontSettings !== "undefined") {
+				// Supports chrome.fontSettings
+				chrome.fontSettings.getFontList((data) => {
+					fonts = ["Default"];
+					for (let font of data) {
+						fonts.push(font.displayName);
+					}
+					sendMessage("GOT_FONTS", fonts);
+				});
+			} else {
+				Promise.resolve().then(() => {
+					sendMessage("GOT_FONTS", fonts);
+				});
+			}
 			break;
 	}
 });

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
       "48": "icons/icon-48.png",
       "16": "icons/icon-16.png"
    },
-   "permissions": ["*://*.twitch.tv/*", "declarativeContent", "fontSettings"],
+   "permissions": ["*://*.twitch.tv/*", "declarativeContent", "fontSettings", "tabs"],
    "content_scripts": [{
       "css": ["css/danmaku.css"],
       "matches": ["*://*.twitch.tv/*"],

--- a/popup.js
+++ b/popup.js
@@ -51,7 +51,19 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 			onGotSettings();
 			break;
 		case 'GOT_FONTS':
-			request.data.forEach(font => $('#font').append(`<option value="${font}"${settings.font === font ? ' selected="selected"' : ''}>${font === 'Default' ? chrome.i18n.getMessage('default') : font}</option>`));
+      if (request.data.length > 0) {
+        request.data.forEach((font) =>
+          $("#font").append(
+            `<option value="${font}"${
+              settings.font === font ? ' selected="selected"' : ""
+            }>${
+              font === "Default" ? chrome.i18n.getMessage("default") : font
+            }</option>`
+          )
+        );
+      } else {
+        $("#font").closest("li").hide();
+      }
 			break;
 	}
 });

--- a/popup.js
+++ b/popup.js
@@ -51,19 +51,19 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 			onGotSettings();
 			break;
 		case 'GOT_FONTS':
-      if (request.data.length > 0) {
-        request.data.forEach((font) =>
-          $("#font").append(
-            `<option value="${font}"${
-              settings.font === font ? ' selected="selected"' : ""
-            }>${
-              font === "Default" ? chrome.i18n.getMessage("default") : font
-            }</option>`
-          )
-        );
-      } else {
-        $("#font").closest("li").hide();
-      }
+			if (request.data.length > 0) {
+				request.data.forEach((font) =>
+					$("#font").append(
+						`<option value="${font}"${
+							settings.font === font ? ' selected="selected"' : ""
+						}>${
+							font === "Default" ? chrome.i18n.getMessage("default") : font
+						}</option>`
+					)
+				);
+			} else {
+				$("#font").closest("li").hide();
+			}
 			break;
 	}
 });


### PR DESCRIPTION
Ref: #3 

- Add workaround for chrome.declarativeContent api
  - Require "tabs" permission for the workaround
- Bypass retrieving font list from chrome.fontSettings if its not available
- Hide font selection in popout UI if font list length is 0

這個 PR 直接加上 Firefox 的支援，不過由於 Firefox 那邊的 workaround 需要額外的 permission `tabs`，這樣可能會降低在意隱私權的 Chrome 使用者安裝的意願，可能可以考慮用分開的 `manifest.json` 來上架。

**Chrome 的長這樣(沒變)**

```json5
{
    ...,
    "background": {
       "scripts": ["lib/jQuery/jquery-3.3.1.min.js", "background.js"],
       "persistant": false
    },
    ...
    "permissions": ["*://*.twitch.tv/*", "declarativeContent", "fontSettings"],
}
```

**Firefox 的長這樣**

```json5
{
    ...,
    "background": {
       "scripts": ["lib/jQuery/jquery-3.3.1.min.js", "background.js"],
        // Firefox 不支援 persistant: false
    },
    ...
    // 拿掉不支援的 permission，加上 workaround 用的 "tabs"
    "permissions": ["*://*.twitch.tv/*", "tabs"],
}
```